### PR TITLE
Add two Mappings for Victron Serial

### DIFF
--- a/lib/victron_serial/victron_smartshunt.py
+++ b/lib/victron_serial/victron_smartshunt.py
@@ -37,6 +37,7 @@ class Smartshunt:
         'VS': ("Latest", "Starter Battery Voltage", "V", 0.001, helper.convert_int_factor),
         'I': ("Latest", "Current", "A", 0.001, helper.convert_int_factor),
         'P': ("Latest", "Power", "W", 1, helper.convert_int_factor),
+        'T': ("Latest", "Battery Temperature", "°C", 1, helper.convert_int_factor),
         'CE': ("Latest", "Used Energy", "Ah", 0.001, helper.convert_int_factor),
         'SOC': ("Battery", "State Of Charge", "%", 0.1, helper.convert_int_factor),
         'TTG': ("Battery", "Time To Go", "Min", 1, helper.convert_int_factor),

--- a/lib/victron_serial/victron_smartsolar.py
+++ b/lib/victron_serial/victron_smartsolar.py
@@ -17,6 +17,7 @@ class Smartsolar:
     MAP = {
         'V': ("Latest", "Voltage", "V", 0.001, helper.convert_int_factor),
         'I': ("Latest", "Current", "A", 0.001, helper.convert_int_factor),
+        'IL': ("Latest", "Load Current", "A", 0.001, helper.convert_int_factor),
         'VPV': ("Latest", "Voltage Panel", "V", 0.001, helper.convert_int_factor),
         'PPV': ("Latest", "Power", "W", 1, helper.convert_int_factor),
         'CS': ("Latest", "Status", "", CS, helper.convert_map_out),


### PR DESCRIPTION
I got some warnings because of missing Mapping Entries :-) 

This PR adds:
Smartshunt (500A): T (External Battery Temperature Sensor)
Smartsolar (MPPT 75/15): IL (Load Current)
