### PR TITLE
Update typed-ast

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ PyGObject==3.38.0
 regex==2020.10.28
 toml==0.10.2
 traitlets==5.0.5
-typed-ast==1.4.1
+typed-ast==1.4.3
 typing-extensions==3.7.4.3
 wcwidth==0.2.5
 pyyaml


### PR DESCRIPTION
1.4.3 has this fix, which fixes compilation on Ubuntu 22.04 https://github.com/python/typed_ast/pull/158