### PR TITLE
Don't crash on non-mqtt logger

### DIFF
--- a/lib/victron.py
+++ b/lib/victron.py
@@ -36,7 +36,7 @@ class Victron:
         if self.victron_type is None:
             logger.error(f"{self.device_config['name']}: Missing or unknown device type")
 
-        if self.config['mqtt']['hass'] and self.config['logger'] == 'mqtt':
+        if self.config['logger'] == 'mqtt' and self.config['mqtt']['hass']:
             pid, ser, fw = self.victron_type.get_device_info()
             mapping_table = self.victron_type.get_mapping_table()
             helper.send_hass_config_payload(self.device_config['name'],


### PR DESCRIPTION
Don't crash if mqtt block is not present but the logger is not mqtt.