### PR TITLE
[WIP] Don't stop on serial read with no data

### DIFF
--- a/lib/victron_serial/victron_serial.py
+++ b/lib/victron_serial/victron_serial.py
@@ -11,11 +11,15 @@ logger = logging.getLogger()
 def read_data_callback(self, callbackFunction):
     self.keep_running = True
     while self.keep_running:
-        data = self.ser.read()
-        for byte in data:
-            packet = self.input(byte)
-            if (packet != None):
-                callbackFunction(packet)
+        try:
+          data = self.ser.read()
+        except:
+          logging.info(f'Serial read returned no data')
+        else:
+            for byte in data:
+                packet = self.input(byte)
+                if (packet != None):
+                    callbackFunction(packet)
 Vedirect.read_data_callback = read_data_callback
 
 class VictronSerial:


### PR DESCRIPTION
This isn't quite right, though it keeps the process running when a serial read returns no data.

for example, this data shows the Deepest Discharge value as incorrect with this patch:

BMV:SmartShunt 300A
Firmware Version:4.19
MON ?:0
Deepest Discharge:-H5   0
Last Discharge:-42.51

a normal read looks like:
Deepest Discharge:-71.22

My pythonista creds are quite junior; I haven't figured out yet how to avoid this situation. Maybe somebody can improve this.